### PR TITLE
Prevent NPE on onHostResume

### DIFF
--- a/android/src/main/java/com/mybigday/rnmediaplayer/ExternalDisplay.java
+++ b/android/src/main/java/com/mybigday/rnmediaplayer/ExternalDisplay.java
@@ -142,7 +142,7 @@ public class ExternalDisplay implements LifecycleEventListener, ExternalDisplayH
     if (alreadyStarted) return;
     initLayoutView();
     tryShowPreview();
-    
+
     root = new Root(context, reactContext, containerView);
     alreadyStarted = true;
   }
@@ -244,14 +244,20 @@ public class ExternalDisplay implements LifecycleEventListener, ExternalDisplayH
   @Override
   public void onHostResume() {
     start();
-    helper.onResume();
+    // Don't know why this would be null at this point
+    if (helper != null) {
+      helper.onResume();
+    }
     showVirtualScreen(true);
   }
 
   @Override
   public void onHostPause() {
     showVirtualScreen(false);
-    helper.onPause();
+    // Don't know why this would be null at this point
+    if (helper != null) {
+      helper.onResume();
+    }
     tryRemovePreview();
   }
 

--- a/android/src/main/java/com/mybigday/rnmediaplayer/ExternalDisplay.java
+++ b/android/src/main/java/com/mybigday/rnmediaplayer/ExternalDisplay.java
@@ -254,10 +254,7 @@ public class ExternalDisplay implements LifecycleEventListener, ExternalDisplayH
   @Override
   public void onHostPause() {
     showVirtualScreen(false);
-    // Don't know why this would be null at this point
-    if (helper != null) {
-      helper.onResume();
-    }
+    helper.onResume();
     tryRemovePreview();
   }
 


### PR DESCRIPTION
This call to helper.onResume() was causing intermittent NPE's
They happened during app initialization but I could not identify the reason; usually after a reload
Adding a null check on onHostPause as well, just in case