### PR TITLE
Add react namespace to RCT header imports

### DIFF
--- a/ios/RNMediaPlayer/RNMediaPlayer.h
+++ b/ios/RNMediaPlayer/RNMediaPlayer.h
@@ -8,8 +8,8 @@
 
 @import Foundation;
 @import UIKit;
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcher.h>
 #import "Container.h"
 #import "ImageContainer.h"
 #import "VideoContainer.h"

--- a/ios/RNMediaPlayer/RNMediaPlayer.h
+++ b/ios/RNMediaPlayer/RNMediaPlayer.h
@@ -8,8 +8,19 @@
 
 @import Foundation;
 @import UIKit;
+
+// import RCTBridgeModule.h
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
 #import <React/RCTEventDispatcher.h>
+#else
+#import "RCTEventDispatcher.h"
+#endif
+
 #import "Container.h"
 #import "ImageContainer.h"
 #import "VideoContainer.h"


### PR DESCRIPTION
Required to support react native version greater than 0.40